### PR TITLE
Normalize gate and ralph verdict parsing

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -12,6 +12,7 @@ import { agentLoop, loopEvents, type LoopConfig, type LoopResult } from './loop.
 import { renderTemplate } from './template.js'
 import { loadCookMD } from './template.js'
 import { createSessionLog, appendToLog } from './log.js'
+import { parseRalphVerdict } from './verdict.js'
 import {
   sessionId,
   createWorktree,
@@ -94,6 +95,25 @@ on its own line, followed by a brief reason.
 
 DONE if: the work is complete and no High severity issues remain.
 ITERATE if: there are High severity issues or the work is incomplete.`
+
+function formatGatePrompt(prompt?: string): string {
+  if (!prompt) return DEFAULT_GATE_PROMPT
+  if (/respond with exactly done or iterate/i.test(prompt)) return prompt
+  return `Based on the review, decide whether to stop or continue.
+Respond with exactly DONE or ITERATE on its own line, followed by a brief reason.
+
+Criteria:
+${prompt}`
+}
+
+function formatRalphGatePrompt(prompt: string): string {
+  if (/respond with exactly (?:done or next|next or done)/i.test(prompt)) return prompt
+  return `Decide whether to advance to the next task or stop.
+Respond with exactly NEXT or DONE on its own line, followed by a brief reason.
+
+Criteria:
+${prompt}`
+}
 
 // --- Work: single agent call ---
 
@@ -217,7 +237,7 @@ async function executeReview(
       const loopConfig: LoopConfig = {
         workPrompt: iteratePrompt,
         reviewPrompt: node.reviewPrompt ?? DEFAULT_REVIEW_PROMPT,
-        gatePrompt: node.gatePrompt ?? DEFAULT_GATE_PROMPT,
+        gatePrompt: formatGatePrompt(node.gatePrompt),
         iteratePrompt: node.iteratePrompt,
         steps: ctx.stepConfig,
         maxIterations: node.maxIterations,
@@ -263,7 +283,7 @@ async function executeReview(
     const loopConfig: LoopConfig = {
       workPrompt,
       reviewPrompt: node.reviewPrompt ?? DEFAULT_REVIEW_PROMPT,
-      gatePrompt: node.gatePrompt ?? DEFAULT_GATE_PROMPT,
+      gatePrompt: formatGatePrompt(node.gatePrompt),
       iteratePrompt: node.iteratePrompt,
       steps: ctx.stepConfig,
       maxIterations: node.maxIterations,
@@ -329,7 +349,7 @@ async function executeRalph(
 
       const prompt = renderTemplate(ctx.cookMD, {
         step: 'ralph',
-        prompt: node.gatePrompt,
+        prompt: formatRalphGatePrompt(node.gatePrompt),
         lastMessage: result.lastMessage,
         iteration: task,
         maxIterations: node.maxTasks,
@@ -346,7 +366,7 @@ async function executeRalph(
       })
 
       // Parse ralph verdict: NEXT or DONE
-      const verdict = parseRalphVerdict(output)
+      const verdict = parseRalphVerdictOrFallback(output)
       if (verdict === 'DONE') {
         logOK(`Ralph: DONE after ${task} tasks`)
         return { ...result, lastMessage: output }
@@ -362,15 +382,9 @@ async function executeRalph(
   }
 }
 
-const NEXT_KEYWORDS = ['NEXT', 'CONTINUE']
-const RALPH_DONE_KEYWORDS = ['DONE', 'COMPLETE', 'FINISHED']
-
-function parseRalphVerdict(output: string): 'NEXT' | 'DONE' {
-  for (const line of output.split('\n')) {
-    const upper = line.trim().toUpperCase()
-    if (RALPH_DONE_KEYWORDS.some(kw => upper.includes(kw))) return 'DONE'
-    if (NEXT_KEYWORDS.some(kw => upper.includes(kw))) return 'NEXT'
-  }
+function parseRalphVerdictOrFallback(output: string): 'NEXT' | 'DONE' {
+  const verdict = parseRalphVerdict(output)
+  if (verdict) return verdict
   logWarn('Ralph gate: no NEXT/DONE verdict found in output — defaulting to DONE (fail-safe)')
   return 'DONE'
 }
@@ -611,7 +625,7 @@ async function executeBranchForComposition(
       const loopConfig: LoopConfig = {
         workPrompt,
         reviewPrompt: node.reviewPrompt ?? DEFAULT_REVIEW_PROMPT,
-        gatePrompt: node.gatePrompt ?? DEFAULT_GATE_PROMPT,
+        gatePrompt: formatGatePrompt(node.gatePrompt),
         iteratePrompt: node.iteratePrompt,
         steps: ctx.stepConfig,
         maxIterations: node.maxIterations,
@@ -666,7 +680,7 @@ async function executeBranchForComposition(
         const ralphStepConfig = ctx.stepConfig.ralph?.agent ? ctx.stepConfig.ralph : ctx.stepConfig.gate
         const prompt = renderTemplate(ctx.cookMD, {
           step: 'ralph',
-          prompt: node.gatePrompt,
+          prompt: formatRalphGatePrompt(node.gatePrompt),
           lastMessage: result.lastMessage,
           iteration: task,
           maxIterations: node.maxTasks,
@@ -682,7 +696,7 @@ async function executeBranchForComposition(
           console.error(`  ${line}`)
         })
 
-        const verdict = parseRalphVerdict(output)
+        const verdict = parseRalphVerdictOrFallback(output)
         if (verdict === 'DONE') {
           return { ...result, lastMessage: output }
         }
@@ -813,7 +827,7 @@ async function resolveMerge(
   const mergeLoopConfig: LoopConfig = {
     workPrompt: mergeWorkPrompt,
     reviewPrompt: DEFAULT_REVIEW_PROMPT,
-    gatePrompt: DEFAULT_GATE_PROMPT,
+    gatePrompt: formatGatePrompt(),
     steps: ctx.stepConfig,
     maxIterations: 3,
     projectRoot: mergeWt.worktreePath,

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -3,6 +3,7 @@ import type { AgentRunner, SandboxMode } from './runner.js'
 import { renderTemplate, type LoopContext } from './template.js'
 import { createSessionLog, appendToLog, logOK, logWarn } from './log.js'
 import type { AgentName, StepName } from './config.js'
+import { parseGateVerdict } from './verdict.js'
 
 interface LoopStepConfig {
   agent: AgentName
@@ -36,17 +37,7 @@ export interface LoopResult {
   logFile: string
 }
 
-const DONE_KEYWORDS = ['DONE', 'PASS', 'COMPLETE', 'APPROVE', 'ACCEPT']
-const ITERATE_KEYWORDS = ['ITERATE', 'REVISE', 'RETRY']
-
-export function parseGateVerdict(output: string): 'DONE' | 'ITERATE' {
-  for (const line of output.split('\n')) {
-    const upper = line.trim().toUpperCase()
-    if (DONE_KEYWORDS.some(kw => upper.includes(kw))) return 'DONE'
-    if (ITERATE_KEYWORDS.some(kw => upper.includes(kw))) return 'ITERATE'
-  }
-  return 'ITERATE'
-}
+export { parseGateVerdict } from './verdict.js'
 
 export const loopEvents = new EventEmitter()
 
@@ -62,8 +53,8 @@ export async function agentLoop(
   let lastMessage = config.initialLastMessage ?? ''
 
   for (let i = 1; i <= config.maxIterations; i++) {
-    // Iteration 1: work → review → gate (or just review → gate if skipFirstWork)
-    // Iteration 2+: iterate (or work) → review → gate
+    // Iteration 1: work -> review -> gate (or just review -> gate if skipFirstWork)
+    // Iteration 2+: iterate (or work) -> review -> gate
     const workStepName: StepName = (i > 1 && config.iteratePrompt) ? 'iterate' : 'work'
     const workPrompt = (i > 1 && config.iteratePrompt) ? config.iteratePrompt : config.workPrompt
 
@@ -122,17 +113,21 @@ export async function agentLoop(
       }
     }
 
-    const verdict = parseGateVerdict(lastMessage)
+    const parsedVerdict = parseGateVerdict(lastMessage)
+    const verdict = parsedVerdict ?? 'ITERATE'
+    if (!parsedVerdict) {
+      logWarn('Gate: no DONE/ITERATE verdict found in output -> defaulting to ITERATE')
+    }
     if (verdict === 'DONE') {
-      logOK('Gate: DONE — loop complete')
+      logOK('Gate: DONE -> loop complete')
       events.emit('done')
       return { verdict: 'DONE', iterations: i, lastMessage, logFile }
     }
     if (i < config.maxIterations) {
-      logWarn(`Gate: ITERATE — continuing to iteration ${i + 1}`)
+      logWarn(`Gate: ITERATE -> continuing to iteration ${i + 1}`)
     }
   }
-  logWarn(`Gate: max iterations (${config.maxIterations}) reached — stopping`)
+  logWarn(`Gate: max iterations (${config.maxIterations}) reached -> stopping`)
   events.emit('done')
   return { verdict: 'MAX_ITERATIONS', iterations: config.maxIterations, lastMessage, logFile }
 }

--- a/src/verdict.ts
+++ b/src/verdict.ts
@@ -1,0 +1,36 @@
+const VERDICT_PREFIX_RE = /^(?:(?:FINAL\s+)?(?:GATE|RALPH)\s+VERDICT|VERDICT|DECISION)\s*[:\-]\s*/
+const VERDICT_TOKEN_RE = /^(DONE|ITERATE|NEXT)\b/
+
+function normalizeVerdictLine(line: string): string {
+  return line
+    .trim()
+    .replace(/^[>\-+*#\d.\)\s]+/, '')
+    .replace(/[`*_]/g, '')
+    .replace(/\s+/g, ' ')
+    .toUpperCase()
+}
+
+function parseVerdictToken(output: string, allowed: readonly string[]): string | null {
+  for (const rawLine of output.split(/\r?\n/)) {
+    let line = normalizeVerdictLine(rawLine)
+    if (!line) continue
+
+    line = line.replace(VERDICT_PREFIX_RE, '')
+
+    const match = line.match(VERDICT_TOKEN_RE)
+    if (match && allowed.includes(match[1])) {
+      return match[1]
+    }
+  }
+  return null
+}
+
+export function parseGateVerdict(output: string): 'DONE' | 'ITERATE' | null {
+  const verdict = parseVerdictToken(output, ['DONE', 'ITERATE'])
+  return verdict === 'DONE' || verdict === 'ITERATE' ? verdict : null
+}
+
+export function parseRalphVerdict(output: string): 'NEXT' | 'DONE' | null {
+  const verdict = parseVerdictToken(output, ['NEXT', 'DONE'])
+  return verdict === 'NEXT' || verdict === 'DONE' ? verdict : null
+}


### PR DESCRIPTION
## Summary
- add a shared verdict parser for gate and ralph outputs
- parse normalized verdict tokens instead of broad substring matches
- wrap custom gate prompts so they still request explicit DONE/ITERATE or NEXT/DONE responses

## Verification
- `.\node_modules\.bin\tsc.cmd --noEmit`