### PR TITLE
Fix no-code skill install to not require cloning the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Two ways to get it:
 **Skill (no CLI)** — your agent orchestrates subagents directly:
 
 ```sh
-mkdir -p .claude/skills && cp -r no-code .claude/skills/cook
+mkdir -p .claude/skills/cook && curl -fsSL https://raw.githubusercontent.com/rjcorwin/cook/main/no-code/SKILL.md -o .claude/skills/cook/SKILL.md
 ```
 
 **CLI** — standalone tool for terminal or CI:


### PR DESCRIPTION
## Summary
- The no-code skill install command used `cp -r no-code`, which only works if you've already cloned the repo
- Replaced with a `curl` one-liner that fetches `SKILL.md` directly from GitHub — no clone needed

## Test plan
- [x] Verify the curl URL resolves correctly
- [x] Run the install command in a fresh project directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)