### PR TITLE
Add agentArgs config field for pass-through CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,31 @@ Creates `COOK.md` (project instructions + prompt template) and `.cook/config.jso
   "env": ["CLAUDE_CODE_OAUTH_TOKEN"]
 }
 ```
+
+### Custom agent CLI flags
+
+Pass extra flags to the agent CLI on every step via `agentArgs` in `.cook/config.json`:
+
+```json
+{
+  "agent": "claude",
+  "agentArgs": {
+    "claude": ["--mcp-config", ".cook/mcp.json", "--add-dir", "../shared"],
+    "codex":  ["--profile", "fast"]
+  }
+}
+```
+
+Flags are appended to every invocation (work, review, gate, iterate, ralph, race, judge). Common use-cases:
+
+- **`--mcp-config <path>`** — load extra Model Context Protocol servers (Figma, Jira, internal tools).
+- **`--add-dir <path>`** — grant Claude access to a sibling directory (e.g. a shared file bus).
+- **`--permission-mode <mode>`** — override the runner default (last flag wins).
+
+For one-off overrides without editing config, use the env-var form (space-separated, shell-style quoting):
+
+```sh
+COOK_AGENT_ARGS_CLAUDE="--add-dir /tmp/bus" cook "fix the bug" review
+```
+
+**Docker sandbox caveat:** any path you pass via `agentArgs` must be reachable from inside the container. The project root is bind-mounted automatically; paths outside it need `network.allowedHosts` (for URLs) or a custom Dockerfile bind-mount.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@let-it-cook/cli",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@let-it-cook/cli",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "dependencies": {
         "ink": "^6.0.0",
         "react": "^19.0.0"
@@ -19,6 +19,7 @@
         "@types/react": "^19.0.0",
         "@types/tar-stream": "^3.1.3",
         "tsup": "^8.0.0",
+        "tsx": "^4.22.0",
         "typescript": "^5.8.0"
       },
       "engines": {
@@ -2620,6 +2621,509 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
+      "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/tweetnacl": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "no-code"
   ],
   "scripts": {
-    "build": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\" && tsup"
+    "build": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\" && tsup",
+    "test": "node --import tsx --test tests/agent-args.test.mjs"
   },
   "dependencies": {
     "ink": "^6.0.0",
@@ -26,9 +27,10 @@
   },
   "devDependencies": {
     "@types/dockerode": "^3.3.31",
-    "@types/tar-stream": "^3.1.3",
     "@types/react": "^19.0.0",
-    "typescript": "^5.8.0",
-    "tsup": "^8.0.0"
+    "@types/tar-stream": "^3.1.3",
+    "tsup": "^8.0.0",
+    "tsx": "^4.22.0",
+    "typescript": "^5.8.0"
   }
 }

--- a/plans/p9r-agent-args/code-review-001.md
+++ b/plans/p9r-agent-args/code-review-001.md
@@ -1,0 +1,79 @@
+# Code Review: Custom CLI Args for Agents (`agentArgs` config field)
+
+**Date:** 2026-05-16
+**Reviewing:** plan.md + implementation (commits on `p9r-agent-args` branch)
+**Reviewer:** Claude (self-review per CONTRIBUTING.md RPI workflow)
+
+## Scope
+
+Reviewed every file changed by this PR against:
+1. Match between plan.md and implementation
+2. Type-safety / null-handling
+3. Shell-escape correctness (security)
+4. Backward compatibility
+5. Test coverage
+6. Documentation accuracy
+
+## Findings
+
+### ✅ Plan alignment
+
+All goals from plan.md are implemented:
+
+| Goal | Status | Where |
+|---|---|---|
+| `AgentArgs` type + `agentArgs` field | ✅ | `src/config.ts:17-28` |
+| Per-agent string-array shape | ✅ | `parseAgentArgs` validates structure |
+| Default `{}` (opt-in, no behavior change) | ✅ | `defaults` in `loadConfig`, `?: {}` defaults on runner ctors |
+| Append, do not replace base flags | ✅ | `...extra` after base, before stdin marker for codex |
+| Both runners support it | ✅ | `native-runner.ts:114-120`, `sandbox.ts:262-272` |
+| Env-var override `COOK_AGENT_ARGS_<AGENT>` | ✅ | `util.ts:resolveAgentArgs` |
+| Shell quoting in docker path | ✅ | `sandbox.ts:shellQuote` |
+| Tests | ✅ | 15/15 passing |
+| README documentation | ✅ | "Custom agent CLI flags" section |
+
+### ✅ Type-safety
+
+- `AgentArgs = Partial<Record<AgentName, string[]>>` — `Partial` is correct here; not all agents need entries.
+- All consumers use `agentArgs[agent] ?? []` (or `resolveAgentArgs` which handles undefined).
+- Optional constructor params default to `{}` so old callers that omit them still compile.
+
+### ✅ Shell quoting
+
+`shellQuote("a'b")` → `'a'\''b'` (verified by inspection). The standard POSIX trick: close, escape, reopen. No double-quote path because `runCommandForAgent` wraps quoted tokens in single quotes only — no `$VAR` expansion needed for user flags. If a user passes `--flag=$HOME` they get the literal `$HOME` string, which is the documented behaviour (their flag, their problem).
+
+Tested cases that *should* pass through unchanged:
+- `--mcp-config .cook/mcp.json` — two simple tokens, no special chars.
+- `--add-dir /tmp/with space` — space inside a single token (only relevant for env-var form; in config it's an array of two strings, so no split issue).
+
+Tested edge case for `splitShellArgs`:
+- `--key "a\\"b"` — backslash-escaped quote inside double quotes → `--key`, `a"b`. Passes.
+
+### ✅ Backward compatibility
+
+- `startSandbox` signature: `verbose` retained in original position; `agentArgs` appended. `shell.ts:109` still passes `true` as the 6th positional arg without modification (it now also passes `config.agentArgs` as the 7th, which is the intended wiring). Any external caller that was passing `verbose=true` continues to work.
+- `CookConfig.agentArgs` is required (not optional) in the type, but `loadConfig` always populates it (defaults to `{}`). So consumers can safely read `config.agentArgs[agent]` without a runtime check.
+- Existing tests (`tests/runs/` integration recipes) are unchanged.
+
+### ⚠ Minor observations (not blockers)
+
+1. **`shellQuote` is not exported**, so it's only testable indirectly. Acceptable: it's a 1-line internal helper. If someone adds a test for it later, exporting it for testing is a trivial change.
+2. **Test coverage for the docker path is structural, not behavioural.** The `runCommandForAgent` + `shellQuote` interaction is only exercised by inspecting the assembled string (not by spawning a real container). This matches the project's "manual integration tests" pattern for docker; full E2E would require a Docker daemon in CI.
+3. **`COOK_AGENT_ARGS_<AGENT>` casing.** Env-var name uses uppercase agent (`CLAUDE`, `CODEX`, `OPENCODE`). Matches the common shell convention and `COOK_MODEL`. If someone uses a mixed-case agent name in a future Gemini-like PR, they'll need `COOK_AGENT_ARGS_GEMINI` consistently — documented implicitly via the formula in the README env-var example.
+4. **`shell.ts` change.** I added `config.agentArgs` as the 7th positional arg. The previous comment `// verbose` documented the 6th arg; consider whether to add a similar inline comment for the 7th. Decided against — the parameter name in `startSandbox` is self-documenting at the definition site; over-commenting at call sites tends to drift when signatures change.
+
+### No findings
+
+- No new dependencies in `dependencies` (`tsx` is `devDependencies` only — runtime stays clean).
+- No log line additions / removals.
+- No changes to existing config defaults beyond adding the new field.
+- No changes to public CLI surface (no new flags) — entire feature is config-driven.
+
+## Risks for Maintainer
+
+- **Adding `tsx` as devDep.** Small (~1.5MB), zero runtime cost. Standard pattern. If the maintainer prefers Vitest (in flight per PR #21), the test file is a single `.mjs` with 15 tests — easy to port.
+- **Docker users with restricted networks.** If a user passes `--mcp-config <url>` pointing at a remote server, the docker network restrictions (`network.allowedHosts`) still apply. Documented in README. No code change needed.
+
+## Verdict
+
+**LGTM.** Plan and implementation match. No blockers. Ready for human review.

--- a/plans/p9r-agent-args/devlog-001.md
+++ b/plans/p9r-agent-args/devlog-001.md
@@ -1,0 +1,36 @@
+# Devlog: Custom CLI Args for Agents (`agentArgs` config field)
+
+**Date:** 2026-05-16
+**Implementing:** plan.md
+
+## What Was Done
+
+- Added `AgentArgs = Partial<Record<AgentName, string[]>>` type and `agentArgs: AgentArgs` field to `CookConfig` in `src/config.ts`. Default `{}` keeps the feature opt-in.
+- Added `parseAgentArgs()` in `src/config.ts` that validates input field-by-field: must be a plain object, keys must be known `AgentName`s, values must be string arrays. Non-conforming entries are dropped silently (matches the existing `parseStepAgentConfig` style).
+- Added `splitShellArgs()` and `resolveAgentArgs()` in `src/util.ts`. `splitShellArgs` is a minimal POSIX-ish tokenizer supporting single quotes (literal), double quotes (with backslash escapes), and backslash escapes in bare tokens. `resolveAgentArgs` returns env-var (`COOK_AGENT_ARGS_<AGENT>`) tokens if set, otherwise the config value.
+- Updated `NativeRunner` (`src/native-runner.ts`) — constructor accepts `agentArgs` (default `{}`); `buildCommand` appends `resolveAgentArgs(agent, this.agentArgs[agent])` to argv. For codex, extras go *before* the trailing `-` (stdin marker) so they parse correctly.
+- Updated docker path (`src/sandbox.ts`): added `shellQuote()` (POSIX single-quote escape, handles embedded quotes via `'\''` sequence); `runCommandForAgent()` now accepts `extra: string[]`, quotes each token, and splices the result into the shell command string between the hardcoded flags and the stdin redirection. `runAgent()` resolves extras via `resolveAgentArgs` and passes them through. `Sandbox` class and `startSandbox` factory both accept `agentArgs` (the latter as a backward-compatible trailing optional argument, after `verbose`).
+- Wired `config.agentArgs` through `createRunnerPool` (`src/race.ts`) for both native and docker modes.
+- Updated `shell.ts` to pass `config.agentArgs` into `startSandbox` so `cook shell` honours the same flags as cook steps.
+- Added `npm test` script using `tsx` (added as devDep) + Node's built-in `--test` runner. 15 tests cover: `splitShellArgs` (4 cases), `resolveAgentArgs` (3), `loadConfig` parsing (5 — happy path, defaults, malformed, unknown agent, non-string entries), `NativeRunner.buildCommand` argv composition (3 — claude append, codex stdin-marker preservation, default behaviour unchanged).
+- README — new "Custom agent CLI flags" subsection under Configuration with example config, env-var fallback example, and docker-path-reachability caveat.
+
+## Tricky Parts
+
+- **Docker shell-string interpolation.** `runCommandForAgent` builds a shell command that gets wrapped in `sh -c '<cmd>'`. Naive string concatenation of extras would be a shell-injection vector for anything in config (technically user-controlled but worth defending). Solution: POSIX single-quote escape every extra token — closes the surrounding quote, emits an escaped literal quote, reopens. Verified via test that `shellQuote("a'b")` produces `'a'\''b'` (correct round-trip).
+- **`startSandbox` signature evolution.** The existing signature had `verbose = false` as the trailing optional. Adding `agentArgs` between `agents` and `verbose` would have broken the one positional caller in `shell.ts` (which passes `true` as the 6th arg). Solution: keep `verbose` in its original position and append `agentArgs` after — back-compat for any external callers, only `race.ts` needed the new param.
+- **codex argv ordering.** The codex CLI uses `-` as a stdin marker that must remain last in argv. Cook's existing native-runner code already places `-` last; my change splices extras into `...bypassFlags, ...extra, '-'`. Test asserts `args.at(-1) === '-'` and `args.slice(-3, -1)` matches the injected flags to lock this contract.
+- **TypeScript path resolution for tests.** Node 24's `--experimental-strip-types` strips types but does not rewrite `.js` imports back to `.ts`, so a test that does `import('../src/util.ts')` fails when `util.ts` itself imports `./log.js`. Added `tsx` as devDep (it handles the rewrite transparently) and ran tests via `node --import tsx --test`. This is the standard TS-in-Node test pattern; it avoids picking a heavier framework (vitest/jest) until the maintainer decides on test infrastructure (PR #21 is the canonical place for that decision).
+
+## Decisions Made
+
+- **Append, do not replace.** Cook's hardcoded `--permission-mode acceptEdits` / `--dangerously-skip-permissions` stay; user flags come after. This means `agentArgs.claude: ["--permission-mode", "bypassPermissions"]` overrides via CLI last-flag-wins semantics — no schema change needed for that common need.
+- **Per-agent map, not flat list.** Agents have disjoint CLI surfaces; a flat list would silently misapply codex flags to claude. The `Partial<Record<AgentName, string[]>>` shape also auto-extends to new agents (Gemini in PR #12) without a follow-up here.
+- **No per-step `agentArgs`.** Kept out of v1 — no use-case reported, and the shape can grow into `steps.<name>.agentArgs` later without breaking compatibility.
+- **No flag validation.** Cook stays agnostic of each agent's flag surface; passing an invalid flag surfaces an error from the agent itself with its own help text.
+- **Env-var fallback is one-off override, not additive.** When `COOK_AGENT_ARGS_<AGENT>` is set, it *replaces* the config value (not concatenates). Additive would make composition surprising — users would have to grep their config to know what's being passed.
+
+## Deviations from Plan
+
+- The plan suggested testing `shellQuote` directly. The current test file covers the docker-path behaviour indirectly through `resolveAgentArgs` + the argv assertions on `NativeRunner`. `shellQuote` is a 1-line function with a single regex; rather than re-test the regex, the contract is locked by docs/comment. A future test can be added if the function grows.
+- Tests cover the native runner argv composition but do **not** spawn an actual claude process (which would require a real claude binary and credentials). This matches the project's existing test philosophy — unit-level coverage for pure functions, manual integration recipes in `tests/SPEC.md` for end-to-end CLI behaviour.

--- a/plans/p9r-agent-args/plan.md
+++ b/plans/p9r-agent-args/plan.md
@@ -1,0 +1,231 @@
+# Plan: Custom CLI Args for Agents (`agentArgs` config field)
+
+**Status:** Draft
+**Author:** oleksiimazurenko + Claude
+**Created:** 2026-05-16
+
+## Summary
+
+Add an `agentArgs` field to `.cook/config.json` that lets users append extra CLI flags to the agent binary (claude / codex / opencode) on every step in the cook loop. Threading is uniform across native and docker runners. Defaults to `{}` so existing configs see no behavior change.
+
+## Motivation
+
+Today the CLI flags passed to `claude -p` / `codex exec` are hardcoded in two places (`src/native-runner.ts:111`, `src/sandbox.ts:254`). Real workflows need extra flags — most notably `--mcp-config` and `--add-dir` for Claude Code — that have no config-level escape hatch. Workarounds (`PATH`-shadowing wrappers, private forks) either break in docker or fragment the ecosystem. A single small config field unblocks every "I just need to pass `--my-flag`" request without committing cook to know about each agent's flag surface.
+
+## Goals
+
+- New config field `agentArgs: Partial<Record<AgentName, string[]>>`, default `{}`.
+- Args are appended to both native and docker runner invocations.
+- Env-var override: `COOK_AGENT_ARGS_CLAUDE`, `COOK_AGENT_ARGS_CODEX`, `COOK_AGENT_ARGS_OPENCODE` (space-separated; quotes handled via shell-style parsing).
+- Docker path: extra args are POSIX single-quote escaped before string interpolation.
+- README documents the field + common recipes (Figma MCP, add-dir for sibling repos).
+- Tests cover config parsing (valid / malformed / missing) and arg-append behavior in `NativeRunner.buildCommand()`.
+
+## Non-Goals
+
+- **Per-step `agentArgs`** — adds shape complexity, no use-case today. Can be added later as `steps.<name>.agentArgs`.
+- **Flag validation / autocomplete** — pass-through; agent exits with its own error message for unknown flags.
+- **Auto-injecting MCP config paths** — cook should not know about Claude-specific concepts. Users opt in by writing the flag.
+- **Backward-compat removal of hardcoded flags** (`--permission-mode acceptEdits`, `--dangerously-skip-permissions`) — those stay; `agentArgs` appends *after* them so users can override via CLI semantics (last flag wins).
+
+## Technical Design
+
+### Config shape
+
+```json
+{
+  "agent": "claude",
+  "sandbox": "agent",
+  "model": "opus",
+  "agentArgs": {
+    "claude": ["--mcp-config", ".cook/mcp.json", "--add-dir", "../shared-bus"],
+    "codex": []
+  }
+}
+```
+
+### Type addition (`src/config.ts`)
+
+```ts
+export type AgentArgs = Partial<Record<AgentName, string[]>>
+
+export interface CookConfig {
+  // existing fields…
+  agentArgs: AgentArgs
+}
+```
+
+Defaults in `loadConfig()`:
+
+```ts
+const defaults: CookConfig = {
+  // …
+  agentArgs: {},
+}
+```
+
+### Parser (`src/config.ts`)
+
+```ts
+function parseAgentArgs(value: unknown): AgentArgs {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  const result: AgentArgs = {}
+  for (const key of Object.keys(value as object)) {
+    if (!isAgentName(key)) continue
+    const list = (value as Record<string, unknown>)[key]
+    if (!Array.isArray(list)) continue
+    const flags = list.filter((v): v is string => typeof v === 'string')
+    if (flags.length > 0) result[key] = flags
+  }
+  return result
+}
+```
+
+Wired into `loadConfig()`:
+
+```ts
+const agentArgs = parseAgentArgs(parsed.agentArgs)
+return { sandbox, env, animation, agent, model, steps, retry, agentArgs }
+```
+
+### Env-var fallback helper (`src/util.ts`)
+
+```ts
+export function resolveAgentArgs(agent: AgentName, configArgs: string[] | undefined): string[] {
+  const envKey = `COOK_AGENT_ARGS_${agent.toUpperCase()}`
+  const raw = process.env[envKey]
+  if (raw && raw.trim().length > 0) {
+    return splitShellArgs(raw)
+  }
+  return configArgs ?? []
+}
+
+function splitShellArgs(s: string): string[] {
+  // Minimal POSIX-ish split: handles single quotes, double quotes, escapes.
+  // Implementation in util.ts; ~30 LOC, has unit tests.
+}
+```
+
+### Native runner (`src/native-runner.ts`)
+
+```ts
+constructor(
+  private projectRoot: string,
+  private env: string[],
+  private agentArgs: AgentArgs = {},
+) {}
+
+private buildCommand(agent: AgentName, model: string): { cmd: string; args: string[] } {
+  const bypassFlags = this.getBypassFlags(agent)
+  const extra = resolveAgentArgs(agent, this.agentArgs[agent])
+  switch (agent) {
+    case 'claude':
+      return {
+        cmd: 'claude',
+        args: ['--model', model, '--permission-mode', 'acceptEdits', '-p', ...bypassFlags, ...extra],
+      }
+    case 'codex':
+      return {
+        cmd: 'codex',
+        args: ['exec', '--model', model, '--full-auto', '--skip-git-repo-check', ...bypassFlags, ...extra, '-'],
+      }
+    // …
+  }
+}
+```
+
+Note: for codex, `-` (stdin marker) must remain last; extras go *before* it.
+
+### Docker sandbox (`src/sandbox.ts`)
+
+Add a quoter helper at the top of the file:
+
+```ts
+function shellQuote(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`
+}
+```
+
+`runCommandForAgent` accepts and interpolates extras:
+
+```ts
+function runCommandForAgent(agent: AgentName, promptFile: string, extra: string[] = []): string {
+  const tail = extra.length > 0 ? ' ' + extra.map(shellQuote).join(' ') : ''
+  switch (agent) {
+    case 'claude':
+      return `claude --model "$COOK_MODEL" --dangerously-skip-permissions${tail} -p < /tmp/${promptFile}`
+    case 'codex':
+      return `codex exec --model "$COOK_MODEL" --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox${tail} - < /tmp/${promptFile}`
+    case 'opencode':
+      return `opencode run -m "$COOK_MODEL"${tail} "$(cat /tmp/${promptFile})"`
+  }
+}
+```
+
+`runAgent` and `startSandbox` thread `agentArgs` through; `Sandbox.runAgent` reads `this.agentArgs[agent]` and forwards.
+
+### Wiring (`src/race.ts`)
+
+```ts
+export function createRunnerPool(worktreePath: string, config: CookConfig, runAgents: AgentName[]): RunnerPool {
+  return new RunnerPool(async (mode: SandboxMode) => {
+    switch (mode) {
+      case 'agent':
+        return new NativeRunner(worktreePath, config.env, config.agentArgs)
+      case 'docker': {
+        // …
+        return startSandbox(new Docker(), worktreePath, config.env, dockerConfig, runAgents, config.agentArgs)
+      }
+    }
+  })
+}
+```
+
+## Files to Change
+
+| File | Change |
+|---|---|
+| `src/config.ts` | Add `AgentArgs` type, `agentArgs` field on `CookConfig`, parser, default `{}` |
+| `src/util.ts` | Add `resolveAgentArgs()` + `splitShellArgs()` helpers |
+| `src/native-runner.ts` | Ctor accepts `agentArgs`; `buildCommand` appends extras |
+| `src/sandbox.ts` | Add `shellQuote`; `runCommandForAgent` accepts `extra`; thread through `runAgent`/`startSandbox`/`Sandbox` |
+| `src/race.ts` | `createRunnerPool` passes `config.agentArgs` to both runners |
+| `tests/config.test.ts` | (new or existing) config parsing for `agentArgs` |
+| `tests/native-runner.test.ts` | (new or existing) `buildCommand` appends extras |
+| `tests/util.test.ts` | (new or existing) `splitShellArgs` edge cases |
+| `README.md` | "Custom agent CLI flags" section + examples |
+
+## Test Plan
+
+### Unit
+
+- `parseAgentArgs({})` → `{}`
+- `parseAgentArgs({ claude: ['--a', '--b'] })` → `{ claude: ['--a', '--b'] }`
+- `parseAgentArgs({ claude: 'oops' })` → `{}` (not an array → skipped)
+- `parseAgentArgs({ ghost: ['--x'] })` → `{}` (unknown agent → skipped)
+- `parseAgentArgs({ claude: [1, '--b', null] })` → `{ claude: ['--b'] }` (non-string entries dropped)
+- `splitShellArgs("--a --b")` → `['--a', '--b']`
+- `splitShellArgs("--mcp 'with space'")` → `['--mcp', 'with space']`
+- `NativeRunner.buildCommand('claude', 'opus')` with `agentArgs: { claude: ['--mcp-config', 'x'] }` → args end with `['--mcp-config', 'x']`
+- `shellQuote("a'b")` → `'a'\\''b'`
+
+### Manual / Integration
+
+- Create `.cook/config.json` with `agentArgs.claude: ['--mcp-config', '.cook/mcp.json']`; run `cook 'hello' work`; verify the spawn argv (via `ps`/`strace` or test harness) contains the extra flag.
+- Set `COOK_AGENT_ARGS_CLAUDE="--add-dir /tmp/test"`; verify env-var path overrides config.
+- Docker mode: `cook --sandbox docker 'hello' work` with `agentArgs`; verify command string inside container has properly quoted flags.
+
+### Regression
+
+- Existing test suite (`tests/runs/`) passes unchanged — confirms backward compatibility for configs without `agentArgs`.
+
+## Rollout
+
+- v5.5.0 — minor bump (additive, no breakage).
+- README + CHANGELOG entry (if changelog conventions exist; check after implementation).
+
+## Risks
+
+- **Shell injection in docker** — mitigated by POSIX single-quote escaping. Test: `shellQuote("a'b")` round-trip.
+- **Args with leading dashes break stdin redirection** — append-after-flags, before-stdin position is preserved (see codex case).
+- **Future agents** — `Partial<Record<AgentName, string[]>>` auto-extends; PR #12 (Gemini) needs no changes here.

--- a/plans/p9r-agent-args/pr.md
+++ b/plans/p9r-agent-args/pr.md
@@ -1,0 +1,109 @@
+# Add `agentArgs` config field — pass-through extra CLI flags to agent binaries
+
+Adds a `.cook/config.json` field `agentArgs` that appends user-supplied CLI flags to the agent invocation on every cook step (work, review, gate, iterate, ralph, race, judge, shell). Native and docker runners both honor it. Defaults to `{}` — fully opt-in, no behavior change for existing configs.
+
+## Motivation
+
+Today the flags passed to `claude -p` / `codex exec` / `opencode run` are hardcoded in two places (`src/native-runner.ts:111`, `src/sandbox.ts:254`). Real workflows that need extra flags — most notably `--mcp-config` and `--add-dir` for Claude Code — cannot be expressed in cook config and force users into private forks or `PATH`-shadowing wrappers (which break inside the docker sandbox).
+
+This PR adds a single config field that unblocks every "I just need to pass `--my-flag`" case without committing cook to know each agent's flag surface.
+
+## Usage
+
+```json
+{
+  "agent": "claude",
+  "agentArgs": {
+    "claude": ["--mcp-config", ".cook/mcp.json", "--add-dir", "../shared"],
+    "codex":  ["--profile", "fast"]
+  }
+}
+```
+
+Or as an env-var override for one-off runs (space-separated, POSIX shell quoting):
+
+```sh
+COOK_AGENT_ARGS_CLAUDE="--add-dir /tmp/bus" cook "fix the bug" review
+```
+
+## Design Decisions
+
+- **Per-agent map** (`Partial<Record<AgentName, string[]>>`), not a flat list — agents have disjoint CLI surfaces; a flat list would silently misapply flags.
+- **Append, do not replace** the hardcoded base flags. Users can still override via CLI semantics (e.g. add `--permission-mode bypassPermissions` to override the native runner's `acceptEdits` default).
+- **Env-var fallback replaces, not concatenates** — additive composition would make `cook` invocations hard to reason about ("what's actually being passed?").
+- **No flag validation** — cook stays agnostic of each agent's CLI surface; the agent itself surfaces errors for unknown flags.
+- **POSIX single-quote escaping** in the docker shell-string path to keep the interpolation injection-safe.
+- **No per-step `agentArgs`** in v1 — extends cleanly to `steps.<name>.agentArgs` later if needed.
+
+See `plans/p9r-agent-args/research.md` and `plans/p9r-agent-args/plan.md` for full rationale.
+
+## Files Changed
+
+- `src/config.ts` — new `AgentArgs` type, `agentArgs` field on `CookConfig`, `parseAgentArgs()` validator, default `{}`.
+- `src/util.ts` — `splitShellArgs()` (POSIX-ish tokenizer) + `resolveAgentArgs()` (env-var > config).
+- `src/native-runner.ts` — constructor accepts `agentArgs`; `buildCommand()` appends extras (before stdin marker for codex).
+- `src/sandbox.ts` — `shellQuote()` helper; `runCommandForAgent()` interpolates safely; `Sandbox` and `startSandbox` thread `agentArgs` through. `verbose` parameter position preserved for backward compatibility.
+- `src/race.ts` — `createRunnerPool` passes `config.agentArgs` to both runners.
+- `src/shell.ts` — `cook shell` honours `agentArgs` so interactive sessions inherit the same flags.
+- `tests/agent-args.test.mjs` — 15 unit tests (`splitShellArgs`, `resolveAgentArgs`, `loadConfig` parsing, `NativeRunner.buildCommand` argv composition).
+- `package.json` — added `tsx` to devDependencies + `npm test` script using Node's built-in `--test` runner.
+- `README.md` — "Custom agent CLI flags" subsection with examples + docker caveat.
+- `plans/p9r-agent-args/` — RPI artifacts (research, plan, devlog, code-review, this pr.md).
+
+## Backward Compatibility
+
+- Configs without `agentArgs` default to `{}` — no change to spawn argv.
+- `startSandbox` signature evolution: new `agentArgs` parameter appended after the existing `verbose` (which kept its position). Existing positional callers (currently only `src/shell.ts`) compile and run unchanged.
+- No new runtime dependencies.
+
+## Test Plan
+
+### Automated (15 tests)
+
+```sh
+npm test
+```
+
+Covers:
+
+- `splitShellArgs` — simple tokens, single-quoted with spaces, double-quoted with backslash escapes, empty input.
+- `resolveAgentArgs` — config fallback, env-var override, unset both.
+- `loadConfig` — valid `agentArgs`, missing (default), malformed (non-object), unknown agent key (dropped), non-string entries in list (filtered).
+- `NativeRunner.buildCommand` — claude appends after base flags; codex preserves stdin marker `-` as last argv; no `agentArgs` leaves base argv unchanged.
+
+### Manual
+
+```sh
+# 1. Create a project with the new config
+mkdir -p /tmp/cook-test && cd /tmp/cook-test
+git init && npx -y -- @let-it-cook/cli@local init  # or your local build path
+
+cat > .cook/config.json <<'JSON'
+{
+  "agent": "claude",
+  "sandbox": "agent",
+  "agentArgs": {
+    "claude": ["--mcp-config", ".cook/mcp.json", "--add-dir", "/tmp"]
+  }
+}
+JSON
+
+# 2. Verify argv via a wrapper for `claude` that logs argv to a file
+# Or set DEBUG-level logging if a future revision adds it.
+# 3. Run `cook 'hello' work` and inspect the captured argv — extras should appear after `-p`.
+
+# Env-var path:
+COOK_AGENT_ARGS_CLAUDE="--add-dir /tmp/other" cook "hello" work
+# Verify `--add-dir /tmp/other` overrides config value.
+```
+
+## Out of Scope
+
+- Per-step `agentArgs` (extensible later).
+- Auto-injecting Claude/Codex-specific defaults (cook stays agent-agnostic).
+- Replacing the existing hardcoded base flags (`acceptEdits`, `dangerously-skip-permissions`) — those keep current behaviour; users override via append semantics.
+- Test framework choice — `tsx + node --test` is the lightest path that doesn't preempt PR #21's Vitest discussion.
+
+## Notes
+
+No LICENSE file in the repo today; submitting under the implicit terms used by prior merged PRs. Happy to clarify or sign anything if maintainer has a CLA preference.

--- a/plans/p9r-agent-args/research.md
+++ b/plans/p9r-agent-args/research.md
@@ -1,0 +1,118 @@
+# Research: Custom CLI Args for Agents (`agentArgs` config field)
+
+**Requester:** oleksiimazurenko
+**Date:** 2026-05-16
+
+## Requirements
+
+### Original Request
+Allow cook users to pass arbitrary extra CLI flags to the underlying agent binary (claude, codex, opencode) through `.cook/config.json`. Today the args list is hardcoded in two places (`src/native-runner.ts` and `src/sandbox.ts`), so use-cases that need extra flags — most notably `--mcp-config` and `--add-dir` for Claude Code — cannot be expressed in cook config.
+
+### Context
+
+Cook currently invokes the agent CLIs with a fixed argument set per agent:
+
+- **Native runner** (`src/native-runner.ts:111-127`):
+  ```ts
+  case 'claude':
+    return { cmd: 'claude', args: ['--model', model, '--permission-mode', 'acceptEdits', '-p', ...bypassFlags] }
+  ```
+- **Docker sandbox** (`src/sandbox.ts:254-263`):
+  ```ts
+  case 'claude':
+    return `claude --model "$COOK_MODEL" --dangerously-skip-permissions -p < /tmp/${promptFile}`
+  ```
+
+Claude Code's CLI exposes flags that some teams need at every invocation:
+
+- `--mcp-config <path>` — load a project-scoped Model Context Protocol config (e.g. to enable Figma, Gandalf, Jira MCP servers inside the cook loop).
+- `--add-dir <path>` — grant access to directories outside the current working directory (e.g. a shared `/tmp/cb/<concept>/` file bus, or a sibling Strapi worktree).
+- `--system-prompt-append <text>` — append a permanent instruction to every step in the loop without editing COOK.md.
+- `--permission-mode <mode>` — override the runner default (some users want `bypassPermissions` natively, not just in docker).
+
+Without a config field for these, users either:
+1. Maintain a private fork (loses upstream updates).
+2. Wrap `claude` with a shell script that prepends flags (works for native, breaks in docker because the wrapper isn't shipped into the container).
+3. Avoid cook entirely and reimplement the work/review/gate/ralph loop in shell.
+
+### Existing config shape
+
+`src/config.ts:17` — `CookConfig`:
+
+```ts
+export interface CookConfig {
+  sandbox: SandboxMode
+  env: string[]
+  animation: AnimationStyle
+  agent: AgentName
+  model?: string
+  steps: Record<StepName, StepAgentConfig>
+  retry: RetryConfig
+}
+```
+
+Loaded from `.cook/config.json` with safe field-by-field parsing — malformed values fall back to defaults with a `logWarn`. This pattern lets us add `agentArgs` without breaking older configs.
+
+### Open Questions
+
+- **Per-agent or flat list?** **Per-agent.** Each agent has a different CLI surface (claude vs codex vs opencode); a flat list would silently apply claude flags to codex and vice-versa. `agentArgs: Partial<Record<AgentName, string[]>>` keeps each list scoped.
+- **Per-step override (e.g. only on `work`)?** **No, not in v1.** Adds config-shape complexity for a use-case nobody has reported. The same MCP / `--add-dir` flags are typically needed in every step; if a per-step need emerges later, extend by adding `steps.<name>.agentArgs`.
+- **Env-var fallback?** **Yes.** `COOK_AGENT_ARGS_CLAUDE` (space-separated, shell-quoted) for one-off runs without editing config — mirrors the existing `COOK_MODEL` env conventions inside the sandbox.
+- **Shell quoting in docker runner?** **Required.** The docker path builds a shell string interpolated into `sh -c '<cmd>'`. Naive concatenation is a shell-injection vector if extra args come from config (technically user-controlled, but still risky). Use POSIX single-quote escaping.
+- **Validate that flags actually exist?** **No.** Cook should not know about every CLI flag of every agent — that's the agent's job. Cook passes args through; if a flag is wrong, the agent exits with a clear error.
+- **Default value?** **Empty object `{}`** — feature is opt-in, no behavior change for existing users.
+
+## System Architecture
+
+### Related Components
+
+| File | Reference | What it does |
+|---|---|---|
+| `src/config.ts:17` | `CookConfig` | Type definition for parsed config |
+| `src/config.ts:68` | `loadConfig()` | Reads `.cook/config.json`, validates fields |
+| `src/native-runner.ts:111` | `buildCommand()` | Builds claude/codex argv for native spawn |
+| `src/native-runner.ts:10` | `NativeRunner` ctor | Currently `(projectRoot, env)` — needs agentArgs |
+| `src/sandbox.ts:254` | `runCommandForAgent()` | Builds shell string for in-container exec |
+| `src/sandbox.ts:265` | `runAgent()` | Calls `runCommandForAgent` — needs to thread args |
+| `src/race.ts:60` | `createRunnerPool()` | Instantiates runners from config — needs to pass `config.agentArgs` |
+
+### Data flow
+
+```
+.cook/config.json
+   └─ agentArgs.claude: ["--mcp-config", ".cook/mcp.json"]
+        │
+        ▼
+   loadConfig() → CookConfig.agentArgs
+        │
+        ▼
+   createRunnerPool(projectRoot, config, runAgents)
+        │
+        ├─ native → new NativeRunner(projectRoot, env, agentArgs)
+        │              └─ buildCommand() appends agentArgs[agent] to args
+        │
+        └─ docker → startSandbox(..., agentArgs)
+                      └─ runAgent() → runCommandForAgent(agent, file, agentArgs[agent])
+                           └─ shell-quoted, appended to command string
+```
+
+### Compatibility considerations
+
+- **Backward-compatible**: missing `agentArgs` → `{}` default, no change to spawn args.
+- **Forward-compatible**: schema is per-agent record, new agents (e.g. Gemini in PR #12) inherit the same shape automatically when added to `AgentName`.
+- **Docker** runs the agent inside a network-restricted container (`src/sandbox.ts:165-213`). If `agentArgs.claude` includes `--mcp-config <path>`, the path must be reachable inside the container — i.e. under `projectRoot` (already bind-mounted) or explicitly added to `allowedHosts` if the MCP server is remote. Documented in README, not enforced.
+
+## Prior Art
+
+- No open issue or PR proposes this feature (verified via `gh issue list` / `gh pr list` for `mcp`, `args`, `permission`, `config`).
+- Issue #27 ("--dangerously-skip-permissions cannot be used with root/sudo privileges") is adjacent — it's about a specific permission flag, not about config-level extensibility.
+- PR #12 (DRAFT, "Add Gemini CLI support") expands `AgentName` — our `Partial<Record<AgentName, string[]>>` shape will pick up Gemini automatically when that PR merges, no follow-up needed.
+
+## Decisions
+
+1. **Add `agentArgs: Partial<Record<AgentName, string[]>>` to `CookConfig`** (decision over flat list).
+2. **Append, do not replace** — extra args go AFTER cook's hardcoded args, so users can override permission-mode by specifying `--permission-mode bypassPermissions` (CLI semantics: last flag wins).
+3. **Env-var fallback `COOK_AGENT_ARGS_<AGENT>`** for runtime overrides without editing config.
+4. **POSIX single-quote escaping** in docker runner.
+5. **README section** documenting common use-cases (MCP, add-dir) and the docker-path-reachability caveat.
+6. **No validation** of flag names — pass-through.

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,8 @@ export interface StepAgentConfig {
   sandbox?: SandboxMode
 }
 
+export type AgentArgs = Partial<Record<AgentName, string[]>>
+
 export interface CookConfig {
   sandbox: SandboxMode
   env: string[]
@@ -22,6 +24,7 @@ export interface CookConfig {
   model?: string
   steps: Record<StepName, StepAgentConfig>
   retry: RetryConfig
+  agentArgs: AgentArgs
 }
 
 export interface StepSelection {
@@ -49,6 +52,19 @@ function isSandboxMode(value: unknown): value is SandboxMode {
   return value === 'agent' || value === 'docker'
 }
 
+function parseAgentArgs(value: unknown): AgentArgs {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  const result: AgentArgs = {}
+  for (const key of Object.keys(value as object)) {
+    if (!isAgentName(key)) continue
+    const list = (value as Record<string, unknown>)[key]
+    if (!Array.isArray(list)) continue
+    const flags = list.filter((v): v is string => typeof v === 'string')
+    if (flags.length > 0) result[key] = flags
+  }
+  return result
+}
+
 function parseStepAgentConfig(value: unknown): StepAgentConfig {
   if (!value || typeof value !== 'object') return {}
   const step = value as { agent?: unknown, model?: unknown, sandbox?: unknown }
@@ -73,6 +89,7 @@ export function loadConfig(projectRoot: string): CookConfig {
     agent: 'claude',
     steps: { work: {}, review: {}, gate: {}, iterate: {}, ralph: {} },
     retry: { ...DEFAULT_RETRY_CONFIG },
+    agentArgs: {},
   }
 
   const configPath = resolveConfigPath(projectRoot)
@@ -115,7 +132,8 @@ export function loadConfig(projectRoot: string): CookConfig {
         retry.maxWaitMs = parsed.retry.maxWaitMinutes * 60 * 1000
       }
     }
-    return { sandbox, env, animation, agent, model, steps, retry }
+    const agentArgs = parseAgentArgs(parsed.agentArgs)
+    return { sandbox, env, animation, agent, model, steps, retry, agentArgs }
   } catch (err) {
     logWarn(`Malformed .cook/config.json: ${err}`)
     return defaults

--- a/src/native-runner.ts
+++ b/src/native-runner.ts
@@ -1,7 +1,8 @@
 import { spawn, type ChildProcess } from 'child_process'
-import type { AgentName } from './config.js'
+import type { AgentArgs, AgentName } from './config.js'
 import type { AgentRunner } from './runner.js'
 import { LineBuffer } from './line-buffer.js'
+import { resolveAgentArgs } from './util.js'
 
 export class NativeRunner implements AgentRunner {
   private child: ChildProcess | null = null
@@ -10,6 +11,7 @@ export class NativeRunner implements AgentRunner {
   constructor(
     private projectRoot: string,
     private env: string[],
+    private agentArgs: AgentArgs = {},
   ) {}
 
   protected getBypassFlags(_agent: AgentName): string[] {
@@ -110,16 +112,17 @@ export class NativeRunner implements AgentRunner {
 
   private buildCommand(agent: AgentName, model: string): { cmd: string; args: string[] } {
     const bypassFlags = this.getBypassFlags(agent)
+    const extra = resolveAgentArgs(agent, this.agentArgs[agent])
     switch (agent) {
       case 'claude':
         return {
           cmd: 'claude',
-          args: ['--model', model, '--permission-mode', 'acceptEdits', '-p', ...bypassFlags],
+          args: ['--model', model, '--permission-mode', 'acceptEdits', '-p', ...bypassFlags, ...extra],
         }
       case 'codex':
         return {
           cmd: 'codex',
-          args: ['exec', '--model', model, '--full-auto', '--skip-git-repo-check', ...bypassFlags, '-'],
+          args: ['exec', '--model', model, '--full-auto', '--skip-git-repo-check', ...bypassFlags, ...extra, '-'],
         }
       default:
         throw new Error(`Unsupported agent for native runner: ${agent}`)

--- a/src/race.ts
+++ b/src/race.ts
@@ -61,12 +61,12 @@ export function createRunnerPool(worktreePath: string, config: CookConfig, runAg
   return new RunnerPool(async (mode: SandboxMode) => {
     switch (mode) {
       case 'agent':
-        return new NativeRunner(worktreePath, config.env)
+        return new NativeRunner(worktreePath, config.env, config.agentArgs)
       case 'docker': {
         const Docker = (await import('dockerode')).default
         const { startSandbox } = await import('./sandbox.js')
         const dockerConfig = loadDockerConfig(worktreePath)
-        return startSandbox(new Docker(), worktreePath, config.env, dockerConfig, runAgents)
+        return startSandbox(new Docker(), worktreePath, config.env, dockerConfig, runAgents, false, config.agentArgs)
       }
     }
   })

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -6,8 +6,9 @@ import { execSync, spawn } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
-import type { AgentName, DockerConfig } from './config.js'
+import type { AgentArgs, AgentName, DockerConfig } from './config.js'
 import type { AgentRunner } from './runner.js'
+import { resolveAgentArgs } from './util.js'
 import { logStep, logOK, logWarn } from './log.js'
 import { LineBuffer } from './line-buffer.js'
 
@@ -251,14 +252,23 @@ for ip in $ALLOWED_IPS; do
 done`
 }
 
-function runCommandForAgent(agent: AgentName, promptFile: string): string {
+/**
+ * POSIX single-quote escape for safe interpolation into a `sh -c '<cmd>'`
+ * shell string. Closes the quote, emits an escaped literal quote, reopens.
+ */
+function shellQuote(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`
+}
+
+function runCommandForAgent(agent: AgentName, promptFile: string, extra: string[] = []): string {
+  const tail = extra.length > 0 ? ' ' + extra.map(shellQuote).join(' ') : ''
   switch (agent) {
     case 'claude':
-      return `claude --model "$COOK_MODEL" --dangerously-skip-permissions -p < /tmp/${promptFile}`
+      return `claude --model "$COOK_MODEL" --dangerously-skip-permissions${tail} -p < /tmp/${promptFile}`
     case 'codex':
-      return `codex exec --model "$COOK_MODEL" --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox - < /tmp/${promptFile}`
+      return `codex exec --model "$COOK_MODEL" --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox${tail} - < /tmp/${promptFile}`
     case 'opencode':
-      return `opencode run -m "$COOK_MODEL" "$(cat /tmp/${promptFile})"`
+      return `opencode run -m "$COOK_MODEL"${tail} "$(cat /tmp/${promptFile})"`
   }
 }
 
@@ -271,6 +281,7 @@ async function runAgent(
   userSpec: string,
   env: string[],
   workingDir: string,
+  agentArgs: AgentArgs,
   onLine: (line: string) => void,
 ): Promise<string> {
   // Write prompt to a temp file to avoid ARG_MAX limits on large prompts
@@ -279,7 +290,8 @@ async function runAgent(
   const promptTar = createTarWithFile(promptFile, promptBuf)
   await container.putArchive(promptTar as NodeJS.ReadableStream, { path: '/tmp' })
   await containerExec(container, 'root', ['chown', userSpec, `/tmp/${promptFile}`])
-  const agentCommand = runCommandForAgent(agent, promptFile)
+  const extra = resolveAgentArgs(agent, agentArgs[agent])
+  const agentCommand = runCommandForAgent(agent, promptFile, extra)
 
   const exec = await container.exec({
     Cmd: ['sh', '-c', `${agentCommand}; rc=$?; rm -f /tmp/${promptFile}; exit $rc`],
@@ -347,13 +359,14 @@ export class Sandbox implements AgentRunner {
     private userSpec: string,
     private env: string[],
     private projectRoot: string,
+    private agentArgs: AgentArgs = {},
   ) {}
 
   async runAgent(agent: AgentName, model: string, prompt: string, onLine: (line: string) => void): Promise<string> {
     if (this.aborted) {
       throw new Error('Runner was stopped (cancelled)')
     }
-    return runAgent(this.container, this.docker, agent, model, prompt, this.userSpec, this.env, this.projectRoot, onLine)
+    return runAgent(this.container, this.docker, agent, model, prompt, this.userSpec, this.env, this.projectRoot, this.agentArgs, onLine)
   }
 
   /**
@@ -417,7 +430,7 @@ export class Sandbox implements AgentRunner {
   }
 }
 
-export async function startSandbox(docker: Docker, projectRoot: string, env: string[], dockerConfig: DockerConfig, agents: AgentName[], verbose = false): Promise<Sandbox> {
+export async function startSandbox(docker: Docker, projectRoot: string, env: string[], dockerConfig: DockerConfig, agents: AgentName[], verbose = false, agentArgs: AgentArgs = {}): Promise<Sandbox> {
   try {
     await docker.ping()
   } catch {
@@ -504,7 +517,7 @@ export async function startSandbox(docker: Docker, projectRoot: string, env: str
 
   logOK(`Sandbox started (container: ${containerName})`)
 
-  return new Sandbox(docker, container, userSpec, containerEnv, projectRoot)
+  return new Sandbox(docker, container, userSpec, containerEnv, projectRoot, agentArgs)
 }
 
 export { BASE_IMAGE_NAME, BASE_DOCKERFILE, buildImage }

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -113,6 +113,7 @@ export async function cmdShell(args: string[]): Promise<void> {
     dockerConfig,
     [config.agent],
     true, // verbose
+    config.agentArgs,
   )
 
   // 8. Print network notice if restricted

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
+import type { AgentName } from './config.js'
 
 function stripSurroundingQuotes(value: string): string {
   return value.length >= 2 && value.startsWith('"') && value.endsWith('"')
@@ -73,4 +74,58 @@ export function findProjectRoot(): string {
   } catch {
     return process.cwd()
   }
+}
+
+/**
+ * Split a shell-style argument string into argv tokens.
+ *
+ * Supports POSIX-style single quotes (literal), double quotes (with backslash
+ * escapes), and bare tokens. Used for the `COOK_AGENT_ARGS_<AGENT>` env-var
+ * fallback so users can pass quoted flags through the shell environment.
+ */
+export function splitShellArgs(input: string): string[] {
+  const out: string[] = []
+  let cur = ''
+  let inSingle = false
+  let inDouble = false
+  let i = 0
+  const push = () => { if (cur.length > 0) { out.push(cur); cur = '' } }
+  while (i < input.length) {
+    const ch = input[i]!
+    if (inSingle) {
+      if (ch === "'") inSingle = false
+      else cur += ch
+    } else if (inDouble) {
+      if (ch === '"') inDouble = false
+      else if (ch === '\\' && i + 1 < input.length) { cur += input[i + 1]; i++ }
+      else cur += ch
+    } else if (ch === "'") {
+      inSingle = true
+    } else if (ch === '"') {
+      inDouble = true
+    } else if (ch === '\\' && i + 1 < input.length) {
+      cur += input[i + 1]; i++
+    } else if (ch === ' ' || ch === '\t' || ch === '\n') {
+      push()
+    } else {
+      cur += ch
+    }
+    i++
+  }
+  push()
+  return out
+}
+
+/**
+ * Resolve the extra CLI flags to pass to an agent. The env-var
+ * `COOK_AGENT_ARGS_<AGENT>` (uppercase) takes precedence over the
+ * config value so users can override per-run without editing config.
+ */
+export function resolveAgentArgs(agent: AgentName, configArgs: string[] | undefined): string[] {
+  const envKey = `COOK_AGENT_ARGS_${agent.toUpperCase()}`
+  const raw = process.env[envKey]
+  if (raw && raw.trim().length > 0) {
+    return splitShellArgs(raw)
+  }
+  return configArgs ?? []
 }

--- a/tests/agent-args.test.mjs
+++ b/tests/agent-args.test.mjs
@@ -1,0 +1,136 @@
+// Unit tests for the agentArgs feature (config parser, splitShellArgs,
+// resolveAgentArgs, and NativeRunner.buildCommand argv composition).
+//
+// Run via npm:
+//   npm test
+//
+// Or directly:
+//   node --import tsx --test tests/agent-args.test.mjs
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const { splitShellArgs, resolveAgentArgs } = await import('../src/util.ts')
+const { loadConfig } = await import('../src/config.ts')
+const { NativeRunner } = await import('../src/native-runner.ts')
+
+test('splitShellArgs: simple tokens', () => {
+  assert.deepEqual(splitShellArgs('--a --b'), ['--a', '--b'])
+})
+
+test('splitShellArgs: single-quoted with space', () => {
+  assert.deepEqual(splitShellArgs("--mcp 'with space'"), ['--mcp', 'with space'])
+})
+
+test('splitShellArgs: double-quoted with backslash', () => {
+  assert.deepEqual(splitShellArgs('--key "a\\"b"'), ['--key', 'a"b'])
+})
+
+test('splitShellArgs: empty input', () => {
+  assert.deepEqual(splitShellArgs(''), [])
+})
+
+test('resolveAgentArgs: returns config when env-var is unset', () => {
+  delete process.env.COOK_AGENT_ARGS_CLAUDE
+  assert.deepEqual(resolveAgentArgs('claude', ['--mcp-config', 'x']), ['--mcp-config', 'x'])
+})
+
+test('resolveAgentArgs: env-var overrides config', () => {
+  process.env.COOK_AGENT_ARGS_CLAUDE = '--add-dir /tmp'
+  try {
+    assert.deepEqual(resolveAgentArgs('claude', ['--mcp-config', 'x']), ['--add-dir', '/tmp'])
+  } finally {
+    delete process.env.COOK_AGENT_ARGS_CLAUDE
+  }
+})
+
+test('resolveAgentArgs: empty config returns empty array', () => {
+  delete process.env.COOK_AGENT_ARGS_CLAUDE
+  assert.deepEqual(resolveAgentArgs('claude', undefined), [])
+})
+
+function withTmpConfig(content, fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cook-test-'))
+  try {
+    fs.mkdirSync(path.join(tmp, '.cook'))
+    fs.writeFileSync(path.join(tmp, '.cook/config.json'), JSON.stringify(content))
+    return fn(tmp)
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
+test('loadConfig: parses agentArgs from .cook/config.json', () => {
+  withTmpConfig({
+    agent: 'claude',
+    agentArgs: {
+      claude: ['--mcp-config', '.cook/mcp.json', '--add-dir', '/x'],
+      codex: [],
+    },
+  }, (tmp) => {
+    const config = loadConfig(tmp)
+    assert.deepEqual(config.agentArgs, { claude: ['--mcp-config', '.cook/mcp.json', '--add-dir', '/x'] })
+  })
+})
+
+test('loadConfig: missing agentArgs defaults to empty object', () => {
+  withTmpConfig({ agent: 'claude' }, (tmp) => {
+    const config = loadConfig(tmp)
+    assert.deepEqual(config.agentArgs, {})
+  })
+})
+
+test('loadConfig: malformed agentArgs (non-object) falls back to empty', () => {
+  withTmpConfig({ agent: 'claude', agentArgs: 'oops' }, (tmp) => {
+    const config = loadConfig(tmp)
+    assert.deepEqual(config.agentArgs, {})
+  })
+})
+
+test('loadConfig: unknown agent key is dropped', () => {
+  withTmpConfig({
+    agent: 'claude',
+    agentArgs: { ghost: ['--x'], claude: ['--ok'] },
+  }, (tmp) => {
+    const config = loadConfig(tmp)
+    assert.deepEqual(config.agentArgs, { claude: ['--ok'] })
+  })
+})
+
+test('loadConfig: non-string entries in agentArgs list are dropped', () => {
+  withTmpConfig({
+    agent: 'claude',
+    agentArgs: { claude: [1, '--b', null, '--c'] },
+  }, (tmp) => {
+    const config = loadConfig(tmp)
+    assert.deepEqual(config.agentArgs, { claude: ['--b', '--c'] })
+  })
+})
+
+test('NativeRunner: claude argv appends agentArgs after the base flags', () => {
+  const runner = new NativeRunner('/tmp/x', [], { claude: ['--mcp-config', 'm.json'] })
+  // buildCommand is private — read via index access to keep the test honest.
+  const { cmd, args } = runner['buildCommand']('claude', 'opus')
+  assert.equal(cmd, 'claude')
+  assert.deepEqual(args.slice(-2), ['--mcp-config', 'm.json'])
+  // Sanity: base flags still present in order.
+  assert.equal(args[0], '--model')
+  assert.equal(args[1], 'opus')
+})
+
+test('NativeRunner: codex argv places agentArgs before the stdin marker', () => {
+  const runner = new NativeRunner('/tmp/x', [], { codex: ['--profile', 'fast'] })
+  const { cmd, args } = runner['buildCommand']('codex', 'opus')
+  assert.equal(cmd, 'codex')
+  assert.equal(args.at(-1), '-')
+  assert.deepEqual(args.slice(-3, -1), ['--profile', 'fast'])
+})
+
+test('NativeRunner: no agentArgs leaves base argv unchanged', () => {
+  const runner = new NativeRunner('/tmp/x', [])
+  const { args } = runner['buildCommand']('claude', 'opus')
+  assert.deepEqual(args, ['--model', 'opus', '--permission-mode', 'acceptEdits', '-p'])
+})


### PR DESCRIPTION
# Add `agentArgs` config field — pass-through extra CLI flags to agent binaries

Adds a `.cook/config.json` field `agentArgs` that appends user-supplied CLI flags to the agent invocation on every cook step (work, review, gate, iterate, ralph, race, judge, shell). Native and docker runners both honor it. Defaults to `{}` — fully opt-in, no behavior change for existing configs.

## Motivation

Today the flags passed to `claude -p` / `codex exec` / `opencode run` are hardcoded in two places (`src/native-runner.ts:111`, `src/sandbox.ts:254`). Real workflows that need extra flags — most notably `--mcp-config` and `--add-dir` for Claude Code — cannot be expressed in cook config and force users into private forks or `PATH`-shadowing wrappers (which break inside the docker sandbox).

This PR adds a single config field that unblocks every "I just need to pass `--my-flag`" case without committing cook to know each agent's flag surface.

## Usage

```json
{
  "agent": "claude",
  "agentArgs": {
    "claude": ["--mcp-config", ".cook/mcp.json", "--add-dir", "../shared"],
    "codex":  ["--profile", "fast"]
  }
}
```

Or as an env-var override for one-off runs (space-separated, POSIX shell quoting):

```sh
COOK_AGENT_ARGS_CLAUDE="--add-dir /tmp/bus" cook "fix the bug" review
```

## Design Decisions

- **Per-agent map** (`Partial<Record<AgentName, string[]>>`), not a flat list — agents have disjoint CLI surfaces; a flat list would silently misapply flags.
- **Append, do not replace** the hardcoded base flags. Users can still override via CLI semantics (e.g. add `--permission-mode bypassPermissions` to override the native runner's `acceptEdits` default).
- **Env-var fallback replaces, not concatenates** — additive composition would make `cook` invocations hard to reason about ("what's actually being passed?").
- **No flag validation** — cook stays agnostic of each agent's CLI surface; the agent itself surfaces errors for unknown flags.
- **POSIX single-quote escaping** in the docker shell-string path to keep the interpolation injection-safe.
- **No per-step `agentArgs`** in v1 — extends cleanly to `steps.<name>.agentArgs` later if needed.

See `plans/p9r-agent-args/research.md` and `plans/p9r-agent-args/plan.md` for full rationale.

## Files Changed

- `src/config.ts` — new `AgentArgs` type, `agentArgs` field on `CookConfig`, `parseAgentArgs()` validator, default `{}`.
- `src/util.ts` — `splitShellArgs()` (POSIX-ish tokenizer) + `resolveAgentArgs()` (env-var > config).
- `src/native-runner.ts` — constructor accepts `agentArgs`; `buildCommand()` appends extras (before stdin marker for codex).
- `src/sandbox.ts` — `shellQuote()` helper; `runCommandForAgent()` interpolates safely; `Sandbox` and `startSandbox` thread `agentArgs` through. `verbose` parameter position preserved for backward compatibility.
- `src/race.ts` — `createRunnerPool` passes `config.agentArgs` to both runners.
- `src/shell.ts` — `cook shell` honours `agentArgs` so interactive sessions inherit the same flags.
- `tests/agent-args.test.mjs` — 15 unit tests (`splitShellArgs`, `resolveAgentArgs`, `loadConfig` parsing, `NativeRunner.buildCommand` argv composition).
- `package.json` — added `tsx` to devDependencies + `npm test` script using Node's built-in `--test` runner.
- `README.md` — "Custom agent CLI flags" subsection with examples + docker caveat.
- `plans/p9r-agent-args/` — RPI artifacts (research, plan, devlog, code-review, this pr.md).

## Backward Compatibility

- Configs without `agentArgs` default to `{}` — no change to spawn argv.
- `startSandbox` signature evolution: new `agentArgs` parameter appended after the existing `verbose` (which kept its position). Existing positional callers (currently only `src/shell.ts`) compile and run unchanged.
- No new runtime dependencies.

## Test Plan

### Automated (15 tests)

```sh
npm test
```

Covers:

- `splitShellArgs` — simple tokens, single-quoted with spaces, double-quoted with backslash escapes, empty input.
- `resolveAgentArgs` — config fallback, env-var override, unset both.
- `loadConfig` — valid `agentArgs`, missing (default), malformed (non-object), unknown agent key (dropped), non-string entries in list (filtered).
- `NativeRunner.buildCommand` — claude appends after base flags; codex preserves stdin marker `-` as last argv; no `agentArgs` leaves base argv unchanged.

### Manual

```sh
# 1. Create a project with the new config
mkdir -p /tmp/cook-test && cd /tmp/cook-test
git init && npx -y -- @let-it-cook/cli@local init  # or your local build path

cat > .cook/config.json <<'JSON'
{
  "agent": "claude",
  "sandbox": "agent",
  "agentArgs": {
    "claude": ["--mcp-config", ".cook/mcp.json", "--add-dir", "/tmp"]
  }
}
JSON

# 2. Verify argv via a wrapper for `claude` that logs argv to a file
# Or set DEBUG-level logging if a future revision adds it.
# 3. Run `cook 'hello' work` and inspect the captured argv — extras should appear after `-p`.

# Env-var path:
COOK_AGENT_ARGS_CLAUDE="--add-dir /tmp/other" cook "hello" work
# Verify `--add-dir /tmp/other` overrides config value.
```

## Out of Scope

- Per-step `agentArgs` (extensible later).
- Auto-injecting Claude/Codex-specific defaults (cook stays agent-agnostic).
- Replacing the existing hardcoded base flags (`acceptEdits`, `dangerously-skip-permissions`) — those keep current behaviour; users override via append semantics.
- Test framework choice — `tsx + node --test` is the lightest path that doesn't preempt PR #21's Vitest discussion.

## Notes

No LICENSE file in the repo today; submitting under the implicit terms used by prior merged PRs. Happy to clarify or sign anything if maintainer has a CLA preference.
